### PR TITLE
updated dependencies version to be compatible with XamarinStudio

### DIFF
--- a/src/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
+++ b/src/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement.addin.xml
@@ -18,8 +18,8 @@
 	</Runtime>
 
 	<Dependencies>
-		<Addin id="Core" version="3.0.5"/>
-		<Addin id="Ide" version="3.0.5"/>
+		<Addin id="Core" version="4.0"/>
+		<Addin id="Ide" version="4.0"/>
 	</Dependencies>
 	
 	<Extension path = "/MonoDevelop/Ide/Commands/Project">


### PR DESCRIPTION
Hi,

I have updated the dependencies version to be compatible with XamarinStudio. 

Probably worth generating a new add-in repo url for XamarinStudio and keeping the current one for previous MonoDevelop versions. If you decide to create a new repo/branch for Xamarin and want me to send this pull request over there just let me know.

Many thanks,
Franc
