### PR TITLE
Ensure NuGet package restore uses correct mono when switching between parallel mono environments

### DIFF
--- a/src/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/NuGetPackageRestoreCommandLine.cs
+++ b/src/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/NuGetPackageRestoreCommandLine.cs
@@ -61,7 +61,7 @@ namespace ICSharpCode.PackageManagement
 				solution.FileName);
 
 			var monoPrefix = MonoDevelop.Core.Assemblies.MonoRuntimeInfo.FromCurrentRuntime().Prefix;
-			Command = monoPrefix + "/bin/mono";
+			Command = Path.Combine(monoPrefix, "bin", "mono");
 		}
 		
 		void GenerateWindowsCommandLine(IPackageManagementSolution solution)

--- a/src/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/NuGetPackageRestoreCommandLine.cs
+++ b/src/MonoDevelop.PackageManagement/MonoDevelop.PackageManagement/NuGetPackageRestoreCommandLine.cs
@@ -59,8 +59,9 @@ namespace ICSharpCode.PackageManagement
 				"--runtime=v4.0 \"{0}\" restore \"{1}\"",
 				NuGetExePath.GetPath(),
 				solution.FileName);
-			
-			Command = "mono";
+
+			var monoPrefix = MonoDevelop.Core.Assemblies.MonoRuntimeInfo.FromCurrentRuntime().Prefix;
+			Command = monoPrefix + "/bin/mono";
 		}
 		
 		void GenerateWindowsCommandLine(IPackageManagementSolution solution)


### PR DESCRIPTION
Hi Matt,

firstly, thanks for your work on the NuGet addin. I'm currently using Monodevelop 4.1.7 on Ubuntu 13.04 (from PPA https://launchpad.net/~keks9n/+archive/monodevelop-latest) and have come across a potential issue when using the "Restore NuGet packages" menu option. It appears as though the command is being executed with the default mono installation, which is v2.10.8.1 on Ubuntu, even though this instance of MD is running on a parallel mono environment v3.2.1. This causes an exception due to a missing Microsoft.Build.dll.

Using the .NET runtime as configured in MD's Project -> Active Runtime menu appears to ensure the correct parallel mono environment is used and the command works as expected. Would you consider merging the changes in this pull request as it will allow NuGet commands to be executed with whatever runtime is currently active for the project?

Regards,
Kevin
